### PR TITLE
fixed duplicate password icon visibility

### DIFF
--- a/src/pages/AuthHomePage.tsx
+++ b/src/pages/AuthHomePage.tsx
@@ -155,6 +155,11 @@ export const AuthHomePage: React.FC = () => {
           value={signInPassword}
           onChange={(e) => setSignInPassword(e.target.value)}
           required
+          autoComplete="current-password"
+          sx={{
+            '& input[type="password"]::-ms-reveal': { display: 'none' },
+            '& input[type="password"]::-ms-clear': { display: 'none' },
+          }}
           InputProps={{
             endAdornment: (
               <InputAdornment position="end">
@@ -222,6 +227,11 @@ export const AuthHomePage: React.FC = () => {
             'Min 8 characters, at least 1 letter and 1 number'
           }
           required
+          autoComplete="new-password"
+          sx={{
+            '& input[type="password"]::-ms-reveal': { display: 'none' },
+            '& input[type="password"]::-ms-clear': { display: 'none' },
+          }}
           InputProps={{
             endAdornment: (
               <InputAdornment position="end">
@@ -245,6 +255,11 @@ export const AuthHomePage: React.FC = () => {
           error={!!signUpErrors.confirmPassword}
           helperText={signUpErrors.confirmPassword}
           required
+          autoComplete="new-password"
+          sx={{
+            '& input[type="password"]::-ms-reveal': { display: 'none' },
+            '& input[type="password"]::-ms-clear': { display: 'none' },
+          }}
           InputProps={{
             endAdornment: (
               <InputAdornment position="end">

--- a/src/pages/AuthInstitutionPage.tsx
+++ b/src/pages/AuthInstitutionPage.tsx
@@ -144,6 +144,11 @@ export const AuthInstitutionPage: React.FC = () => {
           value={signInPassword}
           onChange={(e) => setSignInPassword(e.target.value)}
           required
+          autoComplete="current-password"
+          sx={{
+            '& input[type="password"]::-ms-reveal': { display: 'none' },
+            '& input[type="password"]::-ms-clear': { display: 'none' },
+          }}
           InputProps={{
             endAdornment: (
               <InputAdornment position="end">
@@ -227,6 +232,11 @@ export const AuthInstitutionPage: React.FC = () => {
           error={!!signUpErrors.password}
           helperText={signUpErrors.password || 'Min 8 characters, at least 1 letter and 1 number'}
           required
+          autoComplete="new-password"
+          sx={{
+            '& input[type="password"]::-ms-reveal': { display: 'none' },
+            '& input[type="password"]::-ms-clear': { display: 'none' },
+          }}
           InputProps={{
             endAdornment: (
               <InputAdornment position="end">
@@ -250,6 +260,11 @@ export const AuthInstitutionPage: React.FC = () => {
           error={!!signUpErrors.confirmPassword}
           helperText={signUpErrors.confirmPassword}
           required
+          autoComplete="new-password"
+          sx={{
+            '& input[type="password"]::-ms-reveal': { display: 'none' },
+            '& input[type="password"]::-ms-clear': { display: 'none' },
+          }}
           InputProps={{
             endAdornment: (
               <InputAdornment position="end">


### PR DESCRIPTION
Resolved an issue where password fields were displaying two visibility (eye) icons. Ensured only the custom lucide toggle icon is rendered by removing browser-injected visibility controls and properly configuring autofill behavior.

**Files Updated:**

- AuthHomePage.tsx
- AuthInstitutionPage.tsx

Result:
Only one lucide visibility toggle icon is displayed, providing a clean and consistent user experience.