### PR TITLE
Story History cards are not center aligned

### DIFF
--- a/src/pages/StoryFavoritesPage.tsx
+++ b/src/pages/StoryFavoritesPage.tsx
@@ -145,7 +145,7 @@ export const StoryFavoritesPage: React.FC = () => {
           </KiddoCard>
         ) : (
           <>
-            <Grid container spacing={3}>
+            <Grid container spacing={3} sx={{ width: "100%" }}>
               {displayedItems.map((item) => (
                 <Grid item xs={12} sm={6} md={4} lg={3} key={item.id}>
                   <KiddoCard

--- a/src/pages/StoryHistoryPage.tsx
+++ b/src/pages/StoryHistoryPage.tsx
@@ -182,7 +182,14 @@ export const StoryHistoryPage: React.FC = () => {
           </KiddoCard>
         ) : (
           <>
-            <Grid container spacing={3}>
+            <Grid
+              container
+              spacing={2}
+              justifyContent="center"
+              sx={{
+                maxWidth: 1400,
+              }}
+            >
               {displayedItems.map((item) => (
                 <Grid item xs={12} sm={6} md={4} lg={3} key={item.id}>
                   <KiddoCard


### PR DESCRIPTION
fix alignment of story history cards, favorites
page cards, and increase container width for better
 display on larger screens
 
 #49 