### PR TITLE
Frontend (Home Mode): Add and Validate Tiny TTS Controls in /home/create-story (ai/sample Integration + Audio Toggle Icon)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4090,24 +4090,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/yaml": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
-      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
-      }
-    },
     "node_modules/zwitch": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",

--- a/src/components/story-creation/StoryPreviewPanel.tsx
+++ b/src/components/story-creation/StoryPreviewPanel.tsx
@@ -8,6 +8,8 @@ import { KiddoCard } from "../index";
 interface StoryPreviewPanelProps {
   generatedStory: string;
   rewrittenStory: string;
+  generatedStoryAudioSrc?: string | null;
+  rewrittenStoryAudioSrc?: string | null;
   onSaveFavorite: () => void;
   isSavingFavorite: boolean;
   isFavoriteSaved: boolean;
@@ -18,6 +20,8 @@ interface StoryPreviewPanelProps {
 export const StoryPreviewPanel: React.FC<StoryPreviewPanelProps> = ({
   generatedStory,
   rewrittenStory,
+  generatedStoryAudioSrc,
+  rewrittenStoryAudioSrc,
   onSaveFavorite,
   isSavingFavorite,
   isFavoriteSaved,
@@ -81,6 +85,13 @@ export const StoryPreviewPanel: React.FC<StoryPreviewPanelProps> = ({
           <Typography variant="h5" sx={{ mb: 2, fontWeight: 600, pr: 5 }}>
             📖 Your Story
           </Typography>
+          {generatedStoryAudioSrc && (
+            <Box sx={{ mb: 2 }}>
+              <audio controls preload="none" src={generatedStoryAudioSrc}>
+                Your browser does not support audio playback.
+              </audio>
+            </Box>
+          )}
           <Box
             sx={{
               typography: "body1",
@@ -108,6 +119,13 @@ export const StoryPreviewPanel: React.FC<StoryPreviewPanelProps> = ({
             <Typography variant="h5" sx={{ mb: 2, fontWeight: 600, color: "primary.main" }}>
               ✨ Refined Story
             </Typography>
+            {rewrittenStoryAudioSrc && (
+              <Box sx={{ mb: 2 }}>
+                <audio controls preload="none" src={rewrittenStoryAudioSrc}>
+                  Your browser does not support audio playback.
+                </audio>
+              </Box>
+            )}
             <Box
               sx={{
                 typography: "body1",

--- a/src/components/story-creation/UnifiedStoryInput.tsx
+++ b/src/components/story-creation/UnifiedStoryInput.tsx
@@ -10,7 +10,7 @@ import {
   IconButton,
   keyframes,
 } from "@mui/material";
-import { ChevronDown, ChevronUp, Shield, Mic, MicOff } from "lucide-react";
+import { ChevronDown, ChevronUp, Shield, Mic, MicOff, Volume2, VolumeX } from "lucide-react";
 import { KiddoCard, KiddoButton } from "../index";
 import { QuickStarterChips } from "./QuickStarterChips";
 import { ImageUploadButton } from "./ImageUploadButton";
@@ -50,6 +50,8 @@ interface UnifiedStoryInputProps {
   setLanguage: (language: string) => void;
   detectedSummary: string;
   onGenerate: () => void;
+  isTtsEnabled: boolean;
+  onToggleTts: () => void;
   isGenerating: boolean;
   errorMessage: string;
   hasExistingStory: boolean;
@@ -100,6 +102,8 @@ export const UnifiedStoryInput: React.FC<UnifiedStoryInputProps> = ({
   setLanguage,
   detectedSummary,
   onGenerate,
+  isTtsEnabled,
+  onToggleTts,
   isGenerating,
   errorMessage,
   hasExistingStory,
@@ -338,6 +342,8 @@ export const UnifiedStoryInput: React.FC<UnifiedStoryInputProps> = ({
         ? "Click to stop recording"
         : "Click to start voice input";
 
+  const ttsColor = isTtsEnabled ? "primary.main" : "error.main";
+
   return (
     <KiddoCard hoverEffect={false} sx={{ p: 4, borderRadius: 2 }}>
       <Stack spacing={3}>
@@ -527,6 +533,39 @@ export const UnifiedStoryInput: React.FC<UnifiedStoryInputProps> = ({
               imagesCount={uploadedImages.length}
               isProcessing={isProcessingImages}
             />
+            <Tooltip
+              title={
+                isTtsEnabled
+                  ? "Audio narration is ON (include_tts=true)"
+                  : "Audio narration is OFF (include_tts=false)"
+              }
+            >
+              <IconButton
+                aria-label={isTtsEnabled ? "Disable audio narration" : "Enable audio narration"}
+                aria-pressed={isTtsEnabled}
+                onClick={onToggleTts}
+                sx={{
+                  color: ttsColor,
+                  width: 40,
+                  height: 40,
+                  borderRadius: "50%",
+                  border: "1px solid",
+                  borderColor: ttsColor,
+                  backgroundColor: isTtsEnabled
+                    ? "rgba(255, 255, 255, 0.95)"
+                    : "rgba(239, 68, 68, 0.12)",
+                  boxShadow: "none",
+                  "&:hover": {
+                    borderColor: ttsColor,
+                    backgroundColor: isTtsEnabled
+                      ? "rgba(255, 255, 255, 1)"
+                      : "rgba(239, 68, 68, 0.18)",
+                  },
+                }}
+              >
+                {isTtsEnabled ? <Volume2 size={18} /> : <VolumeX size={18} />}
+              </IconButton>
+            </Tooltip>
             <Tooltip title={micTooltipText}>
               <span>
                 <IconButton

--- a/src/pages/CreateStoryUnifiedPage.tsx
+++ b/src/pages/CreateStoryUnifiedPage.tsx
@@ -44,6 +44,9 @@ export const CreateStoryUnifiedPage: React.FC = () => {
   // Generated story state
   const [generatedStory, setGeneratedStory] = useState("");
   const [rewrittenStory, setRewrittenStory] = useState("");
+  const [generatedStoryAudioSrc, setGeneratedStoryAudioSrc] = useState<string | null>(null);
+  const [rewrittenStoryAudioSrc, setRewrittenStoryAudioSrc] = useState<string | null>(null);
+  const [isTtsEnabled, setIsTtsEnabled] = useState(true);
 
   // UI state
   const [isGenerating, setIsGenerating] = useState(false);
@@ -230,14 +233,23 @@ export const CreateStoryUnifiedPage: React.FC = () => {
 
       const response = await generateStorySample(
         combinedPrompt,
-        appState.accessToken
+        appState.accessToken,
+        isTtsEnabled
       );
+
+      const ttsAudioSrc =
+        response.tts_audio_base64 && response.tts_media_type
+          ? `data:${response.tts_media_type};base64,${response.tts_audio_base64}`
+          : null;
       
       // If this is a refinement (story already exists), set as rewritten story
       if (generatedStory) {
         setRewrittenStory(response.output);
+        setRewrittenStoryAudioSrc(ttsAudioSrc);
       } else {
         setGeneratedStory(response.output);
+        setGeneratedStoryAudioSrc(ttsAudioSrc);
+        setRewrittenStoryAudioSrc(null);
       }
     } catch (error) {
       const message =
@@ -421,6 +433,8 @@ export const CreateStoryUnifiedPage: React.FC = () => {
           setLanguage={setLanguage}
           detectedSummary={detectedSummary}
           onGenerate={handleGenerate}
+          isTtsEnabled={isTtsEnabled}
+          onToggleTts={() => setIsTtsEnabled((prev) => !prev)}
           isGenerating={isGenerating}
           errorMessage={errorMessage}
           hasExistingStory={!!generatedStory}
@@ -431,6 +445,8 @@ export const CreateStoryUnifiedPage: React.FC = () => {
           <StoryPreviewPanel
             generatedStory={generatedStory}
             rewrittenStory={rewrittenStory}
+            generatedStoryAudioSrc={generatedStoryAudioSrc}
+            rewrittenStoryAudioSrc={rewrittenStoryAudioSrc}
             onSaveFavorite={handleSaveFavorite}
             isSavingFavorite={isSavingFavorite}
             isFavoriteSaved={isFavoriteSaved}

--- a/src/utils/aiApi.ts
+++ b/src/utils/aiApi.ts
@@ -1,5 +1,7 @@
 interface AiSampleResponse {
   output: string;
+  tts_audio_base64?: string | null;
+  tts_media_type?: string | null;
 }
 
 interface RhymeGenerateResponse {
@@ -42,7 +44,8 @@ const resolveApiBaseUrl = (): string => {
 
 export const generateStorySample = async (
   prompt: string,
-  accessToken: string
+  accessToken: string,
+  includeTts = true
 ): Promise<AiSampleResponse> => {
   const apiBaseUrl = resolveApiBaseUrl();
   const response = await fetch(`${apiBaseUrl}/ai/sample`, {
@@ -51,7 +54,7 @@ export const generateStorySample = async (
       'Content-Type': 'application/json',
       Authorization: `Bearer ${accessToken}`,
     },
-    body: JSON.stringify({ prompt }),
+    body: JSON.stringify({ prompt, include_tts: includeTts }),
   });
 
   if (!response.ok) {


### PR DESCRIPTION
This PR covers frontend-only testing and UI wiring for TTS in Home mode on /home/create-story.

**Scope**
- Page: /home/create-story (Home mode flow only)
- API used: POST /ai/sample
- UI addition: tiny audio toggle icon beside camera/mic controls

**What was implemented**
- Added a small speaker toggle button near the camera and microphone icons.
- Connected toggle state directly to include_tts in the ai/sample request:
  - Toggle ON -> include_tts: true
  - Toggle OFF -> include_tts: false
- Added tiny audio playback using HTML audio when TTS data is returned:
- Uses tts_audio_base64 + tts_media_type from ai/sample response
- Renders player in story preview area
- Updated icon behavior to match microphone pattern:
  - ON state: blue style
  - OFF state: red style with crossed icon

**API behavior verified (Home mode)**
- include_tts: true
  - Story text is returned
  - Audio payload is returned and playable in the audio tag
- include_tts: false
  - Story text is still returned
  - Audio player does not appear (no TTS payload expected)

**Testing summary**
- Manual UI test on /home/create-story in Home mode.
- Confirmed toggle drives request payload correctly.
- Confirmed audio player appears only when TTS is enabled and available.
- Confirmed styling and icon-state UX match requested microphone-like pattern.
- Frontend build validation passed.

**Testing Example:**
https://github.com/user-attachments/assets/179d23b5-afdb-4c0f-9546-3223a4daff0f

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/309ae580-0406-4b01-87fa-706bd0519255" />
